### PR TITLE
Convert rate values to floats

### DIFF
--- a/agents/plugins/mk_jolokia.py
+++ b/agents/plugins/mk_jolokia.py
@@ -679,6 +679,8 @@ def generate_values(inst, var_list):
 
         for item, title, value in _process_queries(inst, queries):
             if value_type:
+                if value_type == "rate":
+                    value = "{:f}".format(value)
                 yield item, title, value, value_type
             else:
                 yield item, title, value


### PR DESCRIPTION
Thank you for your interest in contributing to Checkmk!
Consider looking into [Readme](https://github.com/tribe29/checkmk#want-to-contribute) regarding process details.

## General information

Please give a brief summary of the affected device, software or appliance:

* Checkmk Enterprise Edition 2.1.0p13, Jolokia plugin

The Jolokia plugin allows configuring custom MBeans for monitoring. When an attribute returns a value that is close to zero and below the precision of a `float` (e.g. : 1.5060564160797132e-09, or even smaller, like 1e-37), the service is set to "stale" and claims to be unable to fetch a value, although directly calling the plugin from the command line returns the value.

The problem seems to be that the MBean returns a Java `Double`, which the Jolokia plugin (Python) turns into a `float`. Since Python `float`s are C (and Java) `double`s, there is no issue, but the Checkmk server appears to expect C `float`s. My assumption is that the string representation obtained from the plugin cannot be converted correctly, and Checkmk treats this as a failure to obtain the value. (See below.)

## Bug reports

Please include:

+ Your operating system name and version

```
$ uname -a
Linux [HOSTNAME] 4.19.0-19-amd64 #1 SMP Debian 4.19.232-1 (2022-03-07) x86_64 GNU/Linux

$ lsb_release -a
No LSB modules are available.
Distributor ID:	Debian
Description:	Debian GNU/Linux 10 (buster)
Release:	10
Codename:	buster
```

+ Any details about your local setup that might be helpful in troubleshooting

Java application exposing MBeans via Jolokia, that have attributes of type `Double`. But it might not be required, because I think it is a generic problem that could be verified with a "fake" plugin generating the respective, hard-coded output.

+ Detailed steps to reproduce the bug

Not easy to reproduce with Jolokia, but it might be possible to write a small plugin that returns a value like the one provided above. It should make the service stale. (I have not tried that, I am new to Checkmk.)

+ An agent output or SNMP walk

Not applicable.

+ The ID of a submitted crash report for reference (if applicable)

Not applicable.

## Proposed changes

Sometimes it is hard for us to assess the quality of a fix.
While it may work for you, it is our job to ensure that it works for everybody.
These are some ways to help us:

+ What is the expected behavior?

If the number cannot be parsed, users should be informed about the error, instead of "silently" failing with a "stale" state.

If there is a limitation that only C `float` values can be parsed / used in plugin output, it should be documented, and the Jolokia plugin should be fixed to only output compatible values, rounding Python `float`s to C `float`s.

+ What is the observed behavior?

Services go stale, pretending that no value from the MBean could be obtained.

+ If it's not obvious from the above: In what way does your patch change the current behavior?

The patch changes the output so that values of type "rate" are presented as C `float` values, and are correctly understood by Checkmk. It should be seen as a "proof of concept". I do not know Checkmk very well (yet) and it is possible that the issue also affects values of type "number", in which case it might be better to check if `value` is a `float` and always format it accordingly.

+ Consider writing a unit test that would have failed without your fix.

I can do that, but need time to set up a development environment.

+ Is this a new problem? What made you submit this PR (new firmware, new device, changed device behavior)?

I did not find any mention in the issue tracker / PR list, as well as the documentation and forums. I needed the fix to get services out of stale state, because nothing was wrong.
